### PR TITLE
Define `diff.rails_credentials` for git config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Configures AWS credentials
 * Generates the Relay SSH config
+* Configures `diff.rails_credential` for git to diff encrypted rails credential files
 
 ## 2023-03-01 - Relay Fork
 
@@ -43,4 +44,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * [Ignore shellcheck warning SC3043 globally](https://github.com/thoughtbot/laptop/pull/606)
 * [Use gpg-suite-no-mail](https://github.com/thoughtbot/laptop/pull/607)
 * [Update ctags installation command](https://github.com/thoughtbot/laptop/pull/586)
-

--- a/mac
+++ b/mac
@@ -169,6 +169,9 @@ cob = !"git branch -l --format '%(refname:short)' --sort=-committerdate | fzf --
   trustctime = false
   excludesfile = ~/.config/git/ignore
 
+[diff "rails_credentials"]
+  textconv = bin/rails credentials:diff
+
 [delta]
   navigate = true
   side-by-side = true


### PR DESCRIPTION
Allows diffing encrypted rails credential files

- [x] Updated CHANGELOG
- [x] Updated README.md (if necessary)
